### PR TITLE
chore: add .prettierignore configuration and improve script commands

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+public/
+*.log

--- a/package.json
+++ b/package.json
@@ -6,12 +6,12 @@
   "scripts": {
     "build": "vite build",
     "dev": "vite",
-    "format": "prettier --write \"**/*.{ts,tsx,js,jsx,json,md}\"",
-    "format:check": "prettier --check \"**/*.{ts,tsx,js,jsx,json,md}\"",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "preview": "vite preview",
-    "test": "vitest run",
+    "test": "vitest",
     "test:coverage": "vitest run --coverage",
     "test:ui": "vitest --ui"
   },


### PR DESCRIPTION
- Simplified Prettier script commands in `package.json` by using the `.` wildcard for all files.